### PR TITLE
Sd correction slicing condition

### DIFF
--- a/input/fsh/CodeSystem/EclaireStudyPopulationCS.fsh
+++ b/input/fsh/CodeSystem/EclaireStudyPopulationCS.fsh
@@ -1,7 +1,7 @@
 CodeSystem: EclaireStudyPopulationCS
 Id: eclaire-study-population-code-system
-Title: "Code de régulation de l'essai"
-Description: "Code de régulation de l'essai"
+Title: "Codes pour caractériser la population de l'étude"
+Description: "Codes pour caractériser la population ciblée par l'étude"
 * ^caseSensitive = true
 * #incap-pop "Incapacitated population (Population en situation de handicap)"
 * #minors "Minors (Mineurs)"

--- a/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
+++ b/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
@@ -45,15 +45,16 @@ Description: "Profil de ResearchStudy pour le projet ECLAIRE"
 * identifier[idSecondary] ^short = "identifiants secondaires / Secondary Identifying Numbers (e.g., protocol number) if available.  Also include other trial registries that have issued an identifying number to this trial. There is no limit on the number of Secondary identifying numbers that can be provided."
 
 * condition ^slicing.discriminator.type = #value
-* condition ^slicing.discriminator.path = "id"
 * condition ^slicing.rules = #open
-* condition ^slicing.description = "Slicing pour apporter des précisions sur le sujet / Health Condition(s) or Problem(s) Studied"
+* condition ^slicing.description = "Slicing pour apporter des précisions sur le sujet / Health Condition(s) or Problem(s) Studied. Dans le CTIS, il y a un champ texte ouvert (obligatoire) pour indiquer la pathologie et éventuellement des précisons. Un code MedDRA peut-être ajouté mais il est optionnel"
 * condition contains
     medDRACondition 0..* MS and
     diseaseCondition 0..* MS
 * condition[medDRACondition] ^short = "code MedDRA / MedDRA condition"
 * condition[medDRACondition].id = "meddra-condition"
+* condition[medDRACondition].coding.system = "http://terminology.hl7.org/CodeSystem/mdr"
 * condition[diseaseCondition] ^short = "condition de la pathologie / Disease Condition"
+* condition[diseaseCondition].text 1..1
 * condition[diseaseCondition].id = "disease-condition"
 
 /*Extensions*/

--- a/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
+++ b/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
@@ -32,8 +32,8 @@ Description: "Profil de ResearchStudy pour le projet ECLAIRE"
 * location MS
 
 /*slice*/
-//* identifier ^slicing.discriminator.type = #value
-//* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.path = "use"
 * identifier ^slicing.rules = #open
 * identifier ^slicing.description = "Slicing pour les différents identifiants de l'essai clinique"
 * identifier contains
@@ -44,10 +44,8 @@ Description: "Profil de ResearchStudy pour le projet ECLAIRE"
 * identifier[idSecondary].use = #secondary
 * identifier[idSecondary] ^short = "identifiants secondaires / Secondary Identifying Numbers (e.g., protocol number) if available.  Also include other trial registries that have issued an identifying number to this trial. There is no limit on the number of Secondary identifying numbers that can be provided."
 
-* condition ^slicing.discriminator.type = #value
-* condition ^slicing.discriminator.path = "use"
 * condition ^slicing.rules = #open
-* condition ^slicing.description = "Slicing pour apporter des précisions sur le sujet / Health Condition(s) or Problem(s) Studied. Dans le CTIS, il y a un champ texte ouvert (obligatoire) pour indiquer la pathologie et éventuellement des précisons. Un code MedDRA peut-être ajouté mais il est optionnel"
+* condition ^slicing.description = "Slicing pour apporter des précisions sur le sujet / Health Condition(s) or Problem(s) Studied. Dans le CTIS, il y a un champ texte ouvert (obligatoire) pour indiquer la pathologie et éventuellement des précisons. Un code MedDRA peut-être ajouté mais il est optionnel.\nAinsi la slice medDRACondition contient un code meddra, la slice diseaseCondition contient un texte libre. "
 * condition contains
     medDRACondition 0..* MS and
     diseaseCondition 0..* MS

--- a/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
+++ b/input/fsh/StructureDefinition/profiles/ECLAIREResearchStudy.fsh
@@ -32,8 +32,8 @@ Description: "Profil de ResearchStudy pour le projet ECLAIRE"
 * location MS
 
 /*slice*/
-* identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+//* identifier ^slicing.discriminator.type = #value
+//* identifier ^slicing.discriminator.path = "use"
 * identifier ^slicing.rules = #open
 * identifier ^slicing.description = "Slicing pour les différents identifiants de l'essai clinique"
 * identifier contains
@@ -45,6 +45,7 @@ Description: "Profil de ResearchStudy pour le projet ECLAIRE"
 * identifier[idSecondary] ^short = "identifiants secondaires / Secondary Identifying Numbers (e.g., protocol number) if available.  Also include other trial registries that have issued an identifying number to this trial. There is no limit on the number of Secondary identifying numbers that can be provided."
 
 * condition ^slicing.discriminator.type = #value
+* condition ^slicing.discriminator.path = "use"
 * condition ^slicing.rules = #open
 * condition ^slicing.description = "Slicing pour apporter des précisions sur le sujet / Health Condition(s) or Problem(s) Studied. Dans le CTIS, il y a un champ texte ouvert (obligatoire) pour indiquer la pathologie et éventuellement des précisons. Un code MedDRA peut-être ajouté mais il est optionnel"
 * condition contains

--- a/input/fsh/ValueSet/EclaireCategoryVS.fsh
+++ b/input/fsh/ValueSet/EclaireCategoryVS.fsh
@@ -1,6 +1,6 @@
 ValueSet: EclaireCategoryVS
 Id: eclaire-category-vs
 Title: "Value Set type pour spécifier la catégorie l'essai clinique"
-Description: "Value Set our spécifier la catégorie de l'essai clinique et préciser la réglementation ou le code regulation renseigner dans les bases de registre comme CTIS et EUDAMED."
+Description: "Value Set pour spécifier la catégorie de l'essai clinique et préciser la réglementation ou le code regulation renseigner dans les bases de registre comme CTIS et EUDAMED."
 * include codes from system eclaire-reglementation-precision-code-system
 * include codes from system eclaire-regulation-code-code-system

--- a/input/fsh/ValueSet/EclaireStudyPopulationVS.fsh
+++ b/input/fsh/ValueSet/EclaireStudyPopulationVS.fsh
@@ -1,5 +1,5 @@
 ValueSet: EclaireStudyPopulationVS
 Id: eclaire-study-population-vs
-Title: "Caractérisation de la poulation Value Set"
-Description: "Caractérisation de la poulation Value Set."
+Title: "Caractérisation de la population Value Set"
+Description: "Caractérisation de la population Value Set."
 * include codes from system eclaire-study-population-code-system


### PR DESCRIPTION
suite issue #51
@nriss j'ai tenté de retranscrire dans le profiling, le résultat de notre échange sur le slicing de condition:

- enlever le discriminant
- fixer le system pour medDRACondition
- rentre obligatoire le text pour diseaseCondition
- apporter plus d'explication dans la description de la slice
preview https://ansforge.github.io/IG-fhir-essais-cliniques/ig/sd-correction-slicing-condition/StructureDefinition-eclaire-researchstudy.html